### PR TITLE
fix(linux_proxy.py): change desktop detection logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Uniproxy"
-version = "1.1.0"
+version = "1.1.1"
 description="Cross platform python library to set system-wide proxy and bypass domains for proxy."
 authors = ["kun-codes <77796630+throwaway69420-69420@users.noreply.github.com>"]
 license = "LGPL-2.0-or-later"

--- a/uniproxy/linux_proxy.py
+++ b/uniproxy/linux_proxy.py
@@ -17,10 +17,10 @@ class LinuxProxy:
             raise OSError("This library requires GNOME or KDE desktop environment")
 
     def __is_gnome(self):
-        return os.environ.get("XDG_CURRENT_DESKTOP", "").lower() == "gnome"
+        return "gnome" in os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
 
     def __is_kde(self):
-        return os.environ.get("XDG_CURRENT_DESKTOP", "").lower() == "kde"
+        return "kde" in os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
 
     def __get_kde_command(self, command):
         kde_version = os.environ.get("KDE_SESSION_VERSION", "5")
@@ -261,4 +261,3 @@ class LinuxProxy:
             subprocess.run(["systemctl", "--user", "daemon-reload"], check=True)
         except subprocess.CalledProcessError as e:
             print(f"Error refreshing environment variable: {e}")
-


### PR DESCRIPTION
- fixes for ubuntu where `XDG_CURRENT_DESKTOP` is marked something like "ubuntu:gnome" but in a different case